### PR TITLE
Analyze html with drm license for playback

### DIFF
--- a/DRM_Configuration_Guide.md
+++ b/DRM_Configuration_Guide.md
@@ -1,6 +1,6 @@
-# DRM License Configuration Guide for CineCraze
+# MPD DRM License Configuration Guide for CineCraze
 
-This guide explains how to add DRM (Digital Rights Management) license configuration to your JSON data for MPD (MPEG-DASH) streams. The DRM configuration will only be used during playback and **will not affect data fetching**.
+This guide explains how to add DRM (Digital Rights Management) license configuration to your JSON data **specifically for MPD (MPEG-DASH) streams only**. The DRM configuration will only be used during MPD playback and **will not affect data fetching**.
 
 ## Overview
 
@@ -9,13 +9,15 @@ The CineCraze player supports DRM-protected MPD streams with the following DRM s
 - **PlayReady** (Microsoft Edge, Internet Explorer, etc.)
 - **ClearKey** (For testing purposes)
 
+**Important**: DRM configuration is **only applied to MPD (.mpd) files**. Other video formats (MP4, HLS, etc.) will ignore DRM settings.
+
 ## JSON Structure
 
-You can add DRM configuration at different levels in your JSON data:
+You can add MPD DRM configuration at different levels in your JSON data using the `mpdDrm` field:
 
 ### 1. Movie/Live Content Level
 
-For movies and live TV content, add the `drm` section to the content entry:
+For movies and live TV content with MPD streams, add the `mpdDrm` section:
 
 ```json
 {
@@ -32,9 +34,13 @@ For movies and live TV content, add the `drm` section to the content entry:
     {
       "name": "1080p",
       "url": "https://example.com/movie.mpd"
+    },
+    {
+      "name": "720p",
+      "url": "https://example.com/movie_720.mp4"
     }
   ],
-  "drm": {
+  "mpdDrm": {
     "widevine": {
       "licenseUrl": "https://drm-widevine-licensing.example.com/AcquireLicense",
       "headers": {
@@ -54,9 +60,11 @@ For movies and live TV content, add the `drm` section to the content entry:
 }
 ```
 
+**Note**: In this example, DRM will only be applied when playing the `.mpd` file. The `.mp4` file will play normally without DRM.
+
 ### 2. Series Level
 
-For TV series, you can add DRM configuration at the series level (applies to all episodes):
+For TV series with MPD episodes, add DRM configuration at the series level (applies to all MPD episodes):
 
 ```json
 {
@@ -64,7 +72,7 @@ For TV series, you can add DRM configuration at the series level (applies to all
   "Description": "A sample DRM-protected TV series",
   "Type": "Series",
   "Poster": "https://example.com/series-poster.jpg",
-  "drm": {
+  "mpdDrm": {
     "widevine": {
       "licenseUrl": "https://drm-widevine-licensing.example.com/AcquireLicense"
     }
@@ -93,7 +101,7 @@ For TV series, you can add DRM configuration at the series level (applies to all
 
 ### 3. Episode Level
 
-You can also add DRM configuration to individual episodes (overrides series-level DRM):
+You can also add MPD DRM configuration to individual episodes (overrides series-level DRM):
 
 ```json
 {
@@ -106,7 +114,7 @@ You can also add DRM configuration to individual episodes (overrides series-leve
       "url": "https://example.com/special-episode.mpd"
     }
   ],
-  "drm": {
+  "mpdDrm": {
     "widevine": {
       "licenseUrl": "https://different-drm-server.example.com/AcquireLicense",
       "headers": {
@@ -117,7 +125,7 @@ You can also add DRM configuration to individual episodes (overrides series-leve
 }
 ```
 
-## DRM Configuration Options
+## MPD DRM Configuration Options
 
 ### Widevine Configuration
 
@@ -174,7 +182,7 @@ You can also add DRM configuration to individual episodes (overrides series-leve
 
 ## Complete Example
 
-Here's a complete example of a JSON structure with DRM configuration:
+Here's a complete example with mixed content types where only MPD files use DRM:
 
 ```json
 {
@@ -184,7 +192,7 @@ Here's a complete example of a JSON structure with DRM configuration:
       "Entries": [
         {
           "Title": "DRM Protected Movie",
-          "Description": "A movie protected with DRM",
+          "Description": "A movie with both MPD and MP4 versions",
           "Type": "Movie",
           "Poster": "https://example.com/poster.jpg",
           "Thumbnail": "https://example.com/thumb.jpg",
@@ -195,11 +203,15 @@ Here's a complete example of a JSON structure with DRM configuration:
           "SubCategory": "Action",
           "Servers": [
             {
-              "name": "1080p",
+              "name": "1080p DASH",
               "url": "https://example.com/movie.mpd"
+            },
+            {
+              "name": "720p MP4",
+              "url": "https://example.com/movie.mp4"
             }
           ],
-          "drm": {
+          "mpdDrm": {
             "widevine": {
               "licenseUrl": "https://drm-widevine.example.com/license",
               "headers": {
@@ -218,15 +230,15 @@ Here's a complete example of a JSON structure with DRM configuration:
       "MainCategory": "TV Series",
       "Entries": [
         {
-          "Title": "DRM Protected Series",
-          "Description": "A TV series protected with DRM",
+          "Title": "Mixed Format Series",
+          "Description": "A TV series with different episode formats",
           "Type": "Series",
           "Poster": "https://example.com/series-poster.jpg",
           "Year": "2024",
           "Rating": "9.0",
           "Country": "USA",
           "SubCategory": "Drama",
-          "drm": {
+          "mpdDrm": {
             "widevine": {
               "licenseUrl": "https://drm-widevine.example.com/license",
               "headers": {
@@ -241,8 +253,8 @@ Here's a complete example of a JSON structure with DRM configuration:
               "Episodes": [
                 {
                   "Episode": 1,
-                  "Title": "Episode 1",
-                  "Description": "First episode",
+                  "Title": "Episode 1 (MPD with DRM)",
+                  "Description": "MPD episode with DRM protection",
                   "Servers": [
                     {
                       "name": "1080p",
@@ -252,15 +264,26 @@ Here's a complete example of a JSON structure with DRM configuration:
                 },
                 {
                   "Episode": 2,
-                  "Title": "Special Episode",
-                  "Description": "Episode with different DRM",
+                  "Title": "Episode 2 (MP4 without DRM)",
+                  "Description": "MP4 episode without DRM",
                   "Servers": [
                     {
                       "name": "1080p",
-                      "url": "https://example.com/s1e2.mpd"
+                      "url": "https://example.com/s1e2.mp4"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 3,
+                  "Title": "Special Episode (Custom DRM)",
+                  "Description": "MPD episode with custom DRM",
+                  "Servers": [
+                    {
+                      "name": "1080p",
+                      "url": "https://example.com/s1e3.mpd"
                     }
                   ],
-                  "drm": {
+                  "mpdDrm": {
                     "widevine": {
                       "licenseUrl": "https://special-drm.example.com/license",
                       "headers": {
@@ -281,27 +304,38 @@ Here's a complete example of a JSON structure with DRM configuration:
 
 ## Important Notes
 
-1. **DRM Configuration is Optional**: If no DRM configuration is provided, the player will attempt to play the MPD stream without DRM protection.
+1. **MPD Files Only**: DRM configuration is **only applied to MPD (.mpd) files**. Other video formats will ignore DRM settings.
 
-2. **Priority**: Episode-level DRM configuration takes priority over series-level configuration.
+2. **Automatic Detection**: The player automatically detects MPD URLs and applies DRM configuration only when needed.
 
-3. **Browser Support**: 
+3. **Priority**: Episode-level `mpdDrm` configuration takes priority over series-level configuration.
+
+4. **Browser Support**: 
    - Widevine works in Chrome, Firefox, Edge, and most Android browsers
    - PlayReady works in Edge and Internet Explorer on Windows
 
-4. **HTTPS Required**: DRM-protected content requires HTTPS for both the content and license servers.
+5. **HTTPS Required**: DRM-protected content requires HTTPS for both the content and license servers.
 
-5. **CORS**: License servers must be configured to allow cross-origin requests from your domain.
+6. **CORS**: License servers must be configured to allow cross-origin requests from your domain.
 
-6. **No Impact on Data Fetching**: The DRM configuration is only used during playback and does not affect how the JSON data is fetched or processed.
+7. **No Impact on Data Fetching**: The `mpdDrm` configuration is only used during MPD playback and does not affect how the JSON data is fetched or processed.
+
+8. **Mixed Content Support**: You can have both MPD and non-MPD content in the same entry. DRM will only be applied to MPD streams.
 
 ## Testing
 
-You can test your DRM configuration by:
+You can test your MPD DRM configuration by:
 
-1. Adding the DRM section to your JSON data
+1. Adding the `mpdDrm` section to your JSON data for content with MPD URLs
 2. Opening the content in the player
-3. Checking the browser console for DRM-related messages
-4. Verifying that the license requests are being made to your license servers
+3. Selecting the MPD stream from the quality selector
+4. Checking the browser console for DRM-related messages
+5. Using the testing function: `testMPDDRMConfig(mpdDrmConfig, mpdUrl)`
 
-The player will log detailed information about DRM initialization and any errors that occur during the license acquisition process.
+## Console Testing Functions
+
+- `checkDRMSupport()` - Check what DRM systems are supported by the browser
+- `testMPDDRMConfig(config, mpdUrl)` - Test MPD DRM configuration (only works with .mpd URLs)
+- `getPlayerState()` - Get current player and MPD DRM status
+
+The player will log detailed information about DRM initialization and any errors that occur during the license acquisition process for MPD streams only.

--- a/DRM_Configuration_Guide.md
+++ b/DRM_Configuration_Guide.md
@@ -1,0 +1,307 @@
+# DRM License Configuration Guide for CineCraze
+
+This guide explains how to add DRM (Digital Rights Management) license configuration to your JSON data for MPD (MPEG-DASH) streams. The DRM configuration will only be used during playback and **will not affect data fetching**.
+
+## Overview
+
+The CineCraze player supports DRM-protected MPD streams with the following DRM systems:
+- **Widevine** (Google Chrome, Android, etc.)
+- **PlayReady** (Microsoft Edge, Internet Explorer, etc.)
+- **ClearKey** (For testing purposes)
+
+## JSON Structure
+
+You can add DRM configuration at different levels in your JSON data:
+
+### 1. Movie/Live Content Level
+
+For movies and live TV content, add the `drm` section to the content entry:
+
+```json
+{
+  "Title": "Sample Movie",
+  "Description": "A sample DRM-protected movie",
+  "Type": "Movie",
+  "Poster": "https://example.com/poster.jpg",
+  "Thumbnail": "https://example.com/thumb.jpg",
+  "Year": "2024",
+  "Rating": "8.5",
+  "Duration": "120 min",
+  "Country": "USA",
+  "Servers": [
+    {
+      "name": "1080p",
+      "url": "https://example.com/movie.mpd"
+    }
+  ],
+  "drm": {
+    "widevine": {
+      "licenseUrl": "https://drm-widevine-licensing.example.com/AcquireLicense",
+      "headers": {
+        "X-Custom-Header": "custom-value",
+        "Authorization": "Bearer your-token"
+      },
+      "audioRobustness": "SW_SECURE_CRYPTO",
+      "videoRobustness": "SW_SECURE_DECODE"
+    },
+    "playready": {
+      "licenseUrl": "https://drm-playready-licensing.example.com/AcquireLicense",
+      "headers": {
+        "X-Custom-Header": "custom-value"
+      }
+    }
+  }
+}
+```
+
+### 2. Series Level
+
+For TV series, you can add DRM configuration at the series level (applies to all episodes):
+
+```json
+{
+  "Title": "Sample Series",
+  "Description": "A sample DRM-protected TV series",
+  "Type": "Series",
+  "Poster": "https://example.com/series-poster.jpg",
+  "drm": {
+    "widevine": {
+      "licenseUrl": "https://drm-widevine-licensing.example.com/AcquireLicense"
+    }
+  },
+  "Seasons": [
+    {
+      "Season": 1,
+      "SeasonPoster": "https://example.com/season1-poster.jpg",
+      "Episodes": [
+        {
+          "Episode": 1,
+          "Title": "Episode 1",
+          "Description": "First episode",
+          "Servers": [
+            {
+              "name": "1080p",
+              "url": "https://example.com/s1e1.mpd"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 3. Episode Level
+
+You can also add DRM configuration to individual episodes (overrides series-level DRM):
+
+```json
+{
+  "Episode": 1,
+  "Title": "Special Episode",
+  "Description": "This episode has different DRM settings",
+  "Servers": [
+    {
+      "name": "1080p",
+      "url": "https://example.com/special-episode.mpd"
+    }
+  ],
+  "drm": {
+    "widevine": {
+      "licenseUrl": "https://different-drm-server.example.com/AcquireLicense",
+      "headers": {
+        "X-Episode-Token": "special-token"
+      }
+    }
+  }
+}
+```
+
+## DRM Configuration Options
+
+### Widevine Configuration
+
+```json
+"widevine": {
+  "licenseUrl": "https://your-widevine-license-server.com/license",
+  "headers": {
+    "X-Custom-Header": "value",
+    "Authorization": "Bearer token"
+  },
+  "audioRobustness": "SW_SECURE_CRYPTO",
+  "videoRobustness": "SW_SECURE_DECODE"
+}
+```
+
+**Options:**
+- `licenseUrl` (required): The Widevine license server URL
+- `headers` (optional): Custom HTTP headers for license requests
+- `audioRobustness` (optional): Audio robustness level
+  - `SW_SECURE_CRYPTO` (Level 3 - Software)
+  - `SW_SECURE_DECODE` (Level 3 - Software)
+  - `HW_SECURE_CRYPTO` (Level 1 - Hardware)
+  - `HW_SECURE_ALL` (Level 1 - Hardware)
+- `videoRobustness` (optional): Video robustness level (same options as audio)
+
+### PlayReady Configuration
+
+```json
+"playready": {
+  "licenseUrl": "https://your-playready-license-server.com/license",
+  "headers": {
+    "X-Custom-Header": "value"
+  }
+}
+```
+
+**Options:**
+- `licenseUrl` (required): The PlayReady license server URL
+- `headers` (optional): Custom HTTP headers for license requests
+
+### ClearKey Configuration (For Testing)
+
+```json
+"clearkey": {
+  "keys": {
+    "key-id-1": "key-value-1",
+    "key-id-2": "key-value-2"
+  }
+}
+```
+
+**Options:**
+- `keys` (required): Object mapping key IDs to key values
+
+## Complete Example
+
+Here's a complete example of a JSON structure with DRM configuration:
+
+```json
+{
+  "Categories": [
+    {
+      "MainCategory": "Movies",
+      "Entries": [
+        {
+          "Title": "DRM Protected Movie",
+          "Description": "A movie protected with DRM",
+          "Type": "Movie",
+          "Poster": "https://example.com/poster.jpg",
+          "Thumbnail": "https://example.com/thumb.jpg",
+          "Year": "2024",
+          "Rating": "8.5",
+          "Duration": "120 min",
+          "Country": "USA",
+          "SubCategory": "Action",
+          "Servers": [
+            {
+              "name": "1080p",
+              "url": "https://example.com/movie.mpd"
+            }
+          ],
+          "drm": {
+            "widevine": {
+              "licenseUrl": "https://drm-widevine.example.com/license",
+              "headers": {
+                "Authorization": "Bearer your-auth-token"
+              },
+              "videoRobustness": "SW_SECURE_DECODE"
+            },
+            "playready": {
+              "licenseUrl": "https://drm-playready.example.com/license"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "MainCategory": "TV Series",
+      "Entries": [
+        {
+          "Title": "DRM Protected Series",
+          "Description": "A TV series protected with DRM",
+          "Type": "Series",
+          "Poster": "https://example.com/series-poster.jpg",
+          "Year": "2024",
+          "Rating": "9.0",
+          "Country": "USA",
+          "SubCategory": "Drama",
+          "drm": {
+            "widevine": {
+              "licenseUrl": "https://drm-widevine.example.com/license",
+              "headers": {
+                "X-Series-ID": "series-123"
+              }
+            }
+          },
+          "Seasons": [
+            {
+              "Season": 1,
+              "SeasonPoster": "https://example.com/season1.jpg",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Episode 1",
+                  "Description": "First episode",
+                  "Servers": [
+                    {
+                      "name": "1080p",
+                      "url": "https://example.com/s1e1.mpd"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Special Episode",
+                  "Description": "Episode with different DRM",
+                  "Servers": [
+                    {
+                      "name": "1080p",
+                      "url": "https://example.com/s1e2.mpd"
+                    }
+                  ],
+                  "drm": {
+                    "widevine": {
+                      "licenseUrl": "https://special-drm.example.com/license",
+                      "headers": {
+                        "X-Episode-ID": "special-episode"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Important Notes
+
+1. **DRM Configuration is Optional**: If no DRM configuration is provided, the player will attempt to play the MPD stream without DRM protection.
+
+2. **Priority**: Episode-level DRM configuration takes priority over series-level configuration.
+
+3. **Browser Support**: 
+   - Widevine works in Chrome, Firefox, Edge, and most Android browsers
+   - PlayReady works in Edge and Internet Explorer on Windows
+
+4. **HTTPS Required**: DRM-protected content requires HTTPS for both the content and license servers.
+
+5. **CORS**: License servers must be configured to allow cross-origin requests from your domain.
+
+6. **No Impact on Data Fetching**: The DRM configuration is only used during playback and does not affect how the JSON data is fetched or processed.
+
+## Testing
+
+You can test your DRM configuration by:
+
+1. Adding the DRM section to your JSON data
+2. Opening the content in the player
+3. Checking the browser console for DRM-related messages
+4. Verifying that the license requests are being made to your license servers
+
+The player will log detailed information about DRM initialization and any errors that occur during the license acquisition process.

--- a/a2z_mixed_servers_with_drm.json
+++ b/a2z_mixed_servers_with_drm.json
@@ -1,0 +1,44 @@
+{
+  "Title": "A2Z (ABS-CBN)",
+  "SubCategory": "",
+  "Country": "🇵🇭 Philippines",
+  "Description": "A2Z is a Philippine free-to-air blocktime broadcast television network based in Quezon City, with its studios located in Ortigas Center, Pasig. It serves as a flagship property of ZOE Broadcasting Network, the broadcast media arm of Jesus Is Lord Church Worldwide, in partnership with ABS-CBN Corporation as its main content provider through a blocktime agreement.",
+  "Poster": "https://i.imgur.com/43nZ2rv.png",
+  "Thumbnail": "https://i.imgur.com/43nZ2rv.png",
+  "Rating": null,
+  "Duration": "",
+  "Year": 2020,
+  "Servers": [
+    {
+      "name": "1080p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/cg_a2z.mpd"
+    },
+    {
+      "name": "720p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_5.m3u8"
+    },
+    {
+      "name": "480p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_4.m3u8"
+    },
+    {
+      "name": "360p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_3.m3u8"
+    },
+    {
+      "name": "240p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_2.m3u8"
+    },
+    {
+      "name": "144p",
+      "url": "https://qp-pldt-live-grp-02-prod.akamaized.net/out/u/tv5_1.m3u8"
+    }
+  ],
+  "mpdDrm": {
+    "clearkey": {
+      "keys": {
+        "a2z-key-id-here": "a2z-key-value-here"
+      }
+    }
+  }
+}

--- a/example_with_drm.json
+++ b/example_with_drm.json
@@ -1,0 +1,32 @@
+{
+  "Title": "One Sports",
+  "SubCategory": "Sports",
+  "Country": "🇵🇭 Philippines",
+  "Description": "Sports channel covering local and international games.",
+  "Poster": "https://i.imgur.com/iyBXXpU.png",
+  "Thumbnail": "https://i.imgur.com/iyBXXpU.png",
+  "Rating": 4.3,
+  "Duration": "24/7",
+  "Year": 2019,
+  "Servers": [
+    {
+      "name": "HD",
+      "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/cg_onesports_hd.mpd"
+    }
+  ],
+  "mpdDrm": {
+    "widevine": {
+      "licenseUrl": "https://your-widevine-license-server.com/license",
+      "headers": {
+        "Authorization": "Bearer your-auth-token",
+        "X-Channel-ID": "onesports-hd"
+      }
+    },
+    "playready": {
+      "licenseUrl": "https://your-playready-license-server.com/license",
+      "headers": {
+        "Authorization": "Bearer your-auth-token"
+      }
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,38 @@
+# DRM Configuration Examples
+
+This directory contains example JSON files demonstrating how to configure DRM for MPD streams in CineCraze.
+
+## Files
+
+### `sample_drm_data.json`
+Complete example showing various DRM configuration scenarios:
+- Single MPD server with ClearKey DRM
+- Mixed server types (MPD with DRM + HLS without DRM)
+- Series-level DRM configuration
+- Episode-level DRM overrides
+
+## Important Notes
+
+⚠️ **These are examples only** - Replace with your actual:
+- Content URLs
+- License server URLs  
+- Key IDs and keys
+- Authentication tokens
+
+🔒 **Security**: Never commit real DRM keys to public repositories
+
+📖 **Documentation**: See `DRM_Configuration_Guide.md` for complete documentation
+
+## Usage
+
+1. Copy the `mpdDrm` sections from these examples
+2. Replace placeholder values with your actual DRM configuration
+3. Add to your production JSON data
+4. Test with the browser console functions
+
+## Testing
+
+Use these console functions to test your DRM configuration:
+- `checkDRMSupport()` - Check browser DRM support
+- `testMPDDRMConfig(config, mpdUrl)` - Test specific configurations
+- `getPlayerState()` - Check current DRM status

--- a/examples/sample_drm_data.json
+++ b/examples/sample_drm_data.json
@@ -1,0 +1,128 @@
+{
+  "Categories": [
+    {
+      "MainCategory": "Live TV",
+      "Entries": [
+        {
+          "Title": "Sample Sports Channel",
+          "SubCategory": "Sports",
+          "Country": "🇵🇭 Philippines",
+          "Description": "Example sports channel with DRM protection.",
+          "Poster": "https://example.com/sports-poster.png",
+          "Thumbnail": "https://example.com/sports-thumb.png",
+          "Rating": 4.5,
+          "Duration": "24/7",
+          "Year": 2023,
+          "Servers": [
+            {
+              "name": "HD",
+              "url": "https://example.com/sports-hd.mpd"
+            }
+          ],
+          "mpdDrm": {
+            "clearkey": {
+              "keys": {
+                "your-key-id-here": "your-key-value-here"
+              }
+            }
+          }
+        },
+        {
+          "Title": "Mixed Quality Channel",
+          "SubCategory": "Entertainment",
+          "Country": "🇵🇭 Philippines",
+          "Description": "Example channel with mixed server types - only MPD uses DRM.",
+          "Poster": "https://example.com/mixed-poster.png",
+          "Thumbnail": "https://example.com/mixed-thumb.png",
+          "Rating": 4.2,
+          "Duration": "24/7",
+          "Year": 2023,
+          "Servers": [
+            {
+              "name": "1080p",
+              "url": "https://example.com/channel.mpd"
+            },
+            {
+              "name": "720p",
+              "url": "https://example.com/channel_720.m3u8"
+            },
+            {
+              "name": "480p",
+              "url": "https://example.com/channel_480.m3u8"
+            }
+          ],
+          "mpdDrm": {
+            "widevine": {
+              "licenseUrl": "https://your-widevine-server.com/license",
+              "headers": {
+                "Authorization": "Bearer your-token"
+              }
+            },
+            "playready": {
+              "licenseUrl": "https://your-playready-server.com/license"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "MainCategory": "TV Series",
+      "Entries": [
+        {
+          "Title": "Sample DRM Series",
+          "Description": "Example TV series with DRM protection",
+          "Type": "Series",
+          "Poster": "https://example.com/series-poster.jpg",
+          "Year": "2023",
+          "Rating": "8.5",
+          "Country": "USA",
+          "SubCategory": "Drama",
+          "mpdDrm": {
+            "clearkey": {
+              "keys": {
+                "series-key-id": "series-key-value"
+              }
+            }
+          },
+          "Seasons": [
+            {
+              "Season": 1,
+              "SeasonPoster": "https://example.com/season1.jpg",
+              "Episodes": [
+                {
+                  "Episode": 1,
+                  "Title": "Episode 1",
+                  "Description": "First episode with DRM",
+                  "Servers": [
+                    {
+                      "name": "1080p",
+                      "url": "https://example.com/s1e1.mpd"
+                    }
+                  ]
+                },
+                {
+                  "Episode": 2,
+                  "Title": "Special Episode",
+                  "Description": "Episode with custom DRM settings",
+                  "Servers": [
+                    {
+                      "name": "1080p",
+                      "url": "https://example.com/s1e2.mpd"
+                    }
+                  ],
+                  "mpdDrm": {
+                    "clearkey": {
+                      "keys": {
+                        "special-episode-key-id": "special-episode-key-value"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -3243,7 +3243,7 @@
                 description: content.Description,
                 poster: content.Poster || content.Thumbnail,
                 Servers: content.Servers,
-                drm: content.drm // Include DRM configuration if present
+                mpdDrm: content.mpdDrm // Include MPD DRM configuration if present
             };
 
             incrementViewCount(content.Title);
@@ -3570,18 +3570,18 @@
                     video: true
                 };
 
-                // Check for DRM configuration in the current content
-                let drmConfig = null;
-                if (currentContentInfo && currentContentInfo.drm) {
-                    drmConfig = currentContentInfo.drm;
-                    console.log('DRM configuration found:', drmConfig);
-                } else if (currentEpisode && currentEpisode.drm) {
-                    drmConfig = currentEpisode.drm;
-                    console.log('Episode DRM configuration found:', drmConfig);
-                } else if (currentSeries && currentSeries.drm) {
-                    drmConfig = currentSeries.drm;
-                    console.log('Series DRM configuration found:', drmConfig);
-                }
+                            // Check for DRM configuration specifically for MPD streams
+            let drmConfig = null;
+            if (currentContentInfo && currentContentInfo.mpdDrm) {
+                drmConfig = currentContentInfo.mpdDrm;
+                console.log('MPD DRM configuration found:', drmConfig);
+            } else if (currentEpisode && currentEpisode.mpdDrm) {
+                drmConfig = currentEpisode.mpdDrm;
+                console.log('Episode MPD DRM configuration found:', drmConfig);
+            } else if (currentSeries && currentSeries.mpdDrm) {
+                drmConfig = currentSeries.mpdDrm;
+                console.log('Series MPD DRM configuration found:', drmConfig);
+            }
 
                 // Configure DRM if available
                 if (drmConfig) {
@@ -4859,27 +4859,32 @@
                 isPlaying: playerInstance ? !playerInstance.paused : false,
                 hasError: elements.playerMessageArea ? elements.playerMessageArea.style.display !== 'none' : false,
                 errorMessage: elements.playerMessageArea ? elements.playerMessageArea.textContent : null,
-                drmConfig: currentContentInfo ? currentContentInfo.drm : null,
+                mpdDrmConfig: currentContentInfo ? currentContentInfo.mpdDrm : null,
                 currentContent: currentContentInfo ? currentContentInfo.title : null
             };
             console.log('Current player state:', state);
             return state;
         };
 
-        // Function to test DRM configuration
-        window.testDRMConfig = function(drmConfig, mpdUrl) {
+        // Function to test MPD DRM configuration
+        window.testMPDDRMConfig = function(mpdDrmConfig, mpdUrl) {
             if (!mpdUrl) {
                 console.error('MPD URL is required for DRM testing');
                 return;
             }
             
-            console.log('Testing DRM configuration:', drmConfig);
+            if (!isMPDUrl(mpdUrl)) {
+                console.error('Provided URL is not an MPD file. DRM is only for MPD streams.');
+                return;
+            }
+            
+            console.log('Testing MPD DRM configuration:', mpdDrmConfig);
             console.log('MPD URL:', mpdUrl);
             
-            // Temporarily set DRM config for testing
+            // Temporarily set MPD DRM config for testing
             if (currentContentInfo) {
-                currentContentInfo.drm = drmConfig;
-                console.log('DRM config set for testing. Now call playUrl() with the MPD URL.');
+                currentContentInfo.mpdDrm = mpdDrmConfig;
+                console.log('MPD DRM config set for testing. Now call playUrl() with the MPD URL.');
             } else {
                 console.error('No content loaded. Please load content first.');
             }
@@ -4937,7 +4942,7 @@
         console.log('- checkDashSupport(): Check DASH.js support');
         console.log('- getPlayerState(): Get current player state');
         console.log('- checkDRMSupport(): Check DRM system support');
-        console.log('- testDRMConfig(drmConfig, mpdUrl): Test DRM configuration');
+        console.log('- testMPDDRMConfig(mpdDrmConfig, mpdUrl): Test MPD DRM configuration');
         // --- End Test MPD Functionality ---
 
     </script>

--- a/index.html
+++ b/index.html
@@ -3242,7 +3242,8 @@
                 type: content.type,
                 description: content.Description,
                 poster: content.Poster || content.Thumbnail,
-                Servers: content.Servers
+                Servers: content.Servers,
+                drm: content.drm // Include DRM configuration if present
             };
 
             incrementViewCount(content.Title);
@@ -3569,6 +3570,75 @@
                     video: true
                 };
 
+                // Check for DRM configuration in the current content
+                let drmConfig = null;
+                if (currentContentInfo && currentContentInfo.drm) {
+                    drmConfig = currentContentInfo.drm;
+                    console.log('DRM configuration found:', drmConfig);
+                } else if (currentEpisode && currentEpisode.drm) {
+                    drmConfig = currentEpisode.drm;
+                    console.log('Episode DRM configuration found:', drmConfig);
+                } else if (currentSeries && currentSeries.drm) {
+                    drmConfig = currentSeries.drm;
+                    console.log('Series DRM configuration found:', drmConfig);
+                }
+
+                // Configure DRM if available
+                if (drmConfig) {
+                    console.log('Configuring DRM for DASH playback');
+                    
+                    const protectionData = {};
+                    
+                    // Configure Widevine DRM
+                    if (drmConfig.widevine) {
+                        protectionData['com.widevine.alpha'] = {
+                            serverURL: drmConfig.widevine.licenseUrl
+                        };
+                        
+                        // Add custom headers if provided
+                        if (drmConfig.widevine.headers) {
+                            protectionData['com.widevine.alpha'].httpRequestHeaders = drmConfig.widevine.headers;
+                        }
+                        
+                        // Add robustness levels if provided
+                        if (drmConfig.widevine.audioRobustness) {
+                            protectionData['com.widevine.alpha'].audioRobustness = drmConfig.widevine.audioRobustness;
+                        }
+                        if (drmConfig.widevine.videoRobustness) {
+                            protectionData['com.widevine.alpha'].videoRobustness = drmConfig.widevine.videoRobustness;
+                        }
+                    }
+                    
+                    // Configure PlayReady DRM
+                    if (drmConfig.playready) {
+                        protectionData['com.microsoft.playready'] = {
+                            serverURL: drmConfig.playready.licenseUrl
+                        };
+                        
+                        // Add custom headers if provided
+                        if (drmConfig.playready.headers) {
+                            protectionData['com.microsoft.playready'].httpRequestHeaders = drmConfig.playready.headers;
+                        }
+                    }
+                    
+                    // Configure Clearkey DRM (for testing)
+                    if (drmConfig.clearkey) {
+                        protectionData['org.w3.clearkey'] = {
+                            clearkeys: drmConfig.clearkey.keys
+                        };
+                    }
+                    
+                    // Set protection data to DASH player
+                    if (Object.keys(protectionData).length > 0) {
+                        console.log('Setting DRM protection data:', protectionData);
+                        dashPlayer.setProtectionData(protectionData);
+                        
+                        // Show DRM status message
+                        elements.playerMessageArea.textContent = 'Configuring DRM protection...';
+                        elements.playerMessageArea.style.display = 'block';
+                    }
+                }
+
                 // Add comprehensive error handling
                 dashPlayer.on(dashjs.MediaPlayer.events.ERROR, (e) => {
                     console.error('DASH Player Error:', e);
@@ -3612,6 +3682,23 @@
                             }
                         }, 3000);
                     }
+                });
+
+                // Add DRM-specific error handling
+                dashPlayer.on(dashjs.MediaPlayer.events.KEY_ERROR, (e) => {
+                    console.error('DRM Key Error:', e);
+                    elements.playerMessageArea.textContent = 'DRM license error. Content may be restricted.';
+                    elements.playerMessageArea.style.display = 'block';
+                });
+
+                dashPlayer.on(dashjs.MediaPlayer.events.KEY_SESSION_CREATED, (e) => {
+                    console.log('DRM Key Session Created:', e);
+                    elements.playerMessageArea.textContent = 'DRM session established...';
+                    elements.playerMessageArea.style.display = 'block';
+                });
+
+                dashPlayer.on(dashjs.MediaPlayer.events.KEY_STATUSES_MAP_UPDATED, (e) => {
+                    console.log('DRM Key Status Updated:', e);
                 });
 
                 // Add successful initialization handler
@@ -3674,12 +3761,12 @@
                                 console.log('DASH player initialization started for:', url);
                                 
                                 // Show loading message
-                                elements.playerMessageArea.textContent = 'Loading DASH stream...';
+                                elements.playerMessageArea.textContent = drmConfig ? 'Loading DRM-protected DASH stream...' : 'Loading DASH stream...';
                                 elements.playerMessageArea.style.display = 'block';
                                 
                                 // Hide loading message after a timeout if no other events occur
                                 safeSetTimeout(() => {
-                                    if (elements.playerMessageArea.textContent === 'Loading DASH stream...') {
+                                    if (elements.playerMessageArea.textContent.includes('Loading')) {
                                         elements.playerMessageArea.style.display = 'none';
                                     }
                                 }, 10000);
@@ -4771,13 +4858,86 @@
                 playerReady: playerInstance ? playerInstance.ready : false,
                 isPlaying: playerInstance ? !playerInstance.paused : false,
                 hasError: elements.playerMessageArea ? elements.playerMessageArea.style.display !== 'none' : false,
-                errorMessage: elements.playerMessageArea ? elements.playerMessageArea.textContent : null
+                errorMessage: elements.playerMessageArea ? elements.playerMessageArea.textContent : null,
+                drmConfig: currentContentInfo ? currentContentInfo.drm : null,
+                currentContent: currentContentInfo ? currentContentInfo.title : null
             };
             console.log('Current player state:', state);
             return state;
         };
 
-        console.log('MPD test functions loaded. Use testMPDPlayback(), checkDashSupport(), or getPlayerState() in console.');
+        // Function to test DRM configuration
+        window.testDRMConfig = function(drmConfig, mpdUrl) {
+            if (!mpdUrl) {
+                console.error('MPD URL is required for DRM testing');
+                return;
+            }
+            
+            console.log('Testing DRM configuration:', drmConfig);
+            console.log('MPD URL:', mpdUrl);
+            
+            // Temporarily set DRM config for testing
+            if (currentContentInfo) {
+                currentContentInfo.drm = drmConfig;
+                console.log('DRM config set for testing. Now call playUrl() with the MPD URL.');
+            } else {
+                console.error('No content loaded. Please load content first.');
+            }
+        };
+
+        // Function to get DRM system support
+        window.checkDRMSupport = function() {
+            const support = {
+                widevine: false,
+                playready: false,
+                clearkey: false,
+                EME: 'MediaKeys' in window
+            };
+            
+            if (navigator.requestMediaKeySystemAccess) {
+                // Test Widevine
+                navigator.requestMediaKeySystemAccess('com.widevine.alpha', [{}])
+                    .then(() => {
+                        support.widevine = true;
+                        console.log('Widevine DRM: Supported');
+                    })
+                    .catch(() => {
+                        console.log('Widevine DRM: Not supported');
+                    });
+                
+                // Test PlayReady
+                navigator.requestMediaKeySystemAccess('com.microsoft.playready', [{}])
+                    .then(() => {
+                        support.playready = true;
+                        console.log('PlayReady DRM: Supported');
+                    })
+                    .catch(() => {
+                        console.log('PlayReady DRM: Not supported');
+                    });
+                
+                // Test ClearKey
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}])
+                    .then(() => {
+                        support.clearkey = true;
+                        console.log('ClearKey DRM: Supported');
+                    })
+                    .catch(() => {
+                        console.log('ClearKey DRM: Not supported');
+                    });
+            } else {
+                console.log('EME (Encrypted Media Extensions) not supported');
+            }
+            
+            console.log('DRM Support Summary:', support);
+            return support;
+        };
+
+        console.log('MPD and DRM test functions loaded. Available functions:');
+        console.log('- testMPDPlayback(url): Test MPD playback');
+        console.log('- checkDashSupport(): Check DASH.js support');
+        console.log('- getPlayerState(): Get current player state');
+        console.log('- checkDRMSupport(): Check DRM system support');
+        console.log('- testDRMConfig(drmConfig, mpdUrl): Test DRM configuration');
         // --- End Test MPD Functionality ---
 
     </script>

--- a/one_sports_with_clearkey_drm.json
+++ b/one_sports_with_clearkey_drm.json
@@ -1,0 +1,24 @@
+{
+  "Title": "One Sports",
+  "SubCategory": "Sports",
+  "Country": "🇵🇭 Philippines",
+  "Description": "Sports channel covering local and international games.",
+  "Poster": "https://i.imgur.com/iyBXXpU.png",
+  "Thumbnail": "https://i.imgur.com/iyBXXpU.png",
+  "Rating": 4.3,
+  "Duration": "24/7",
+  "Year": 2019,
+  "Servers": [
+    {
+      "name": "HD",
+      "url": "https://qp-pldt-live-grp-07-prod.akamaized.net/out/u/cg_onesports_hd.mpd"
+    }
+  ],
+  "mpdDrm": {
+    "clearkey": {
+      "keys": {
+        "322d06e9326f4753a7ec0908030c13d8": "1e3e0ca32d421fbfec86feced0efefda"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add MPD-specific DRM license support to enable playback of protected DASH content.

This PR introduces a dedicated `mpdDrm` field in the JSON structure and corresponding player logic to ensure DRM configuration is applied solely during MPD playback, without affecting data fetching or other video formats, as specifically requested.

---

[Open in Web](https://www.cursor.com/agents?id=bc-60a8be73-c3b7-4a64-8842-83b918079a11) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-60a8be73-c3b7-4a64-8842-83b918079a11)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)